### PR TITLE
Possible workaround for import error

### DIFF
--- a/ios/Bruh-Bridging-Header.h
+++ b/ios/Bruh-Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  Bruh-Bridging-Header.h
+//  Bruh
+//
+//  Created by John Brunton on 14/08/2020.
+//  Copyright © 2020 Peerspace. All rights reserved.
+//
+
+#import <React/RCTRootView.h>

--- a/ios/Bruh.xcodeproj/project.pbxproj
+++ b/ios/Bruh.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = JeffAlgera.Bruh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Bruh-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -381,6 +382,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = JeffAlgera.Bruh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Bruh-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ios/Bruh.xcworkspace/contents.xcworkspacedata
+++ b/ios/Bruh.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Bruh/../Bruh-Bridging-Header.h">
+   </FileRef>
+   <FileRef
       location = "group:Bruh.xcodeproj">
    </FileRef>
    <FileRef

--- a/ios/Bruh/Info.plist
+++ b/ios/Bruh/Info.plist
@@ -60,5 +60,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/ios/Bruh/ViewController.swift
+++ b/ios/Bruh/ViewController.swift
@@ -7,12 +7,29 @@
 //
 
 import UIKit
-import React
 
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let jsCodeLocation = URL(string: "http://localhost:8081/index.bundle?platform=ios")
+        let mockData:NSDictionary = ["scores":
+            [
+                ["name":"Alex", "value":"42"],
+                ["name":"Joel", "value":"10"]
+            ]
+        ]
+
+        let rootView = RCTRootView(
+            bundleURL: jsCodeLocation!,
+            moduleName: "Bruh",
+            initialProperties: mockData as [NSObject : AnyObject],
+            launchOptions: nil
+        )
+        self.view = rootView
+        //let vc = UIViewController()
+        //vc.view = rootView
+        //self.present(vc, animated: true, completion: nil)
         // Do any additional setup after loading the view.
     }
 

--- a/ios/Bruh/ViewController.swift
+++ b/ios/Bruh/ViewController.swift
@@ -27,10 +27,6 @@ class ViewController: UIViewController {
             launchOptions: nil
         )
         self.view = rootView
-        //let vc = UIViewController()
-        //vc.view = rootView
-        //self.present(vc, animated: true, completion: nil)
-        // Do any additional setup after loading the view.
     }
 
 


### PR DESCRIPTION
I also ran into https://github.com/facebook/react-native/issues/29521. It seems like it's possible to use a bridging header as a workaround for now – here's an example.

Caveat: I'm brand new to native iOS dev so I don't know if there are potential problems lurking, but this lets me run a debug build as expected, at least.